### PR TITLE
fix: 修复类型声明错误

### DIFF
--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -2,7 +2,9 @@ import htmlPlugin from "vite-plugin-html-config";
 
 console.log("htmlPlugin", htmlPlugin);
 
-const htmlPluginOpt = {
+
+module.exports = {
+  plugins: [htmlPlugin({
   favicon: "./logo.svg",
   headScripts: [
     `var msg = 'head script'
@@ -47,8 +49,5 @@ const htmlPluginOpt = {
     },
   ],
   style: `body { color: red; };*{ margin: 0px }`,
-};
-
-module.exports = {
-  plugins: [htmlPlugin(htmlPluginOpt)],
+})],
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,16 @@
 import { Plugin, HtmlTagDescriptor } from "vite";
 export interface IHTMLTag {
-  [key: string]: string;
+  [key: string]: string|boolean;
 }
 
+export type ScriptTag = Record<string, string | boolean>|string
 export interface Options {
   favicon?: string;
   metas?: IHTMLTag[];
   links?: IHTMLTag[];
   style?: string;
-  headScripts?: IHTMLTag[];
-  scripts?: IHTMLTag[];
+  headScripts?: ScriptTag[];
+  scripts?: ScriptTag[];
 }
 export default function HtmlPlugin(rawOptions: Options): Plugin {
   const {
@@ -22,7 +23,7 @@ export default function HtmlPlugin(rawOptions: Options): Plugin {
   } = rawOptions;
 
   const getScriptContent = (
-    script: IHTMLTag,
+    script: ScriptTag,
     injectTo: "head" | "body" | "head-prepend" | "body-prepend"
   ) => {
     let result = {} as HtmlTagDescriptor;


### PR DESCRIPTION
现在的版本在vite vue-ts项目中使用会有类型报错，主要是attrs除了可以string还可以boolean，现在设置为boolean会报错，然后就是script里面可以是对象还可以是string，但是现在类型声明中只能为对象。