### PR TITLE
fix(types): fix path to package types

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
-  "types": "dist/types/src/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "scripts": {
     "dev": "avenger build --watch",
     "build": "avenger build",


### PR DESCRIPTION
trying to import this plugin results in the error
```ts
import htmlPlugin from "vite-plugin-html-config";
// TS2307: Cannot find module vite-plugin-html-config or its corresponding type declarations.
```
This PR fixes the path to package types